### PR TITLE
Updated machinekit-client_mac.ini

### DIFF
--- a/examples/machinekit-client_mac.ini
+++ b/examples/machinekit-client_mac.ini
@@ -6,6 +6,7 @@ platform="mac"
 qtDir="~/Qt5.4.0/5.4/clang_64"
 qmlSourceDir="../QtQuickVcp/applications/AppDiscover"
 applicationDir="../build-AppDiscover-Desktop_Qt_5_4_clang_64bit"
+pkgname="QtQuickVcp"
 
 [GitHub]
 user="strahlex"


### PR DESCRIPTION
Missing `pkgname` option from configuration file.

When trying to execute 
```
$ qt-deploy -v 0.4.0 --deploy --clean MBPMid2010-GPU-Fix-client_mac.ini 
```
Was getting the following error : 

```
Traceback (most recent call last):
  File "/usr/bin/qt-deploy", line 525, in <module>
    deployment.run()
  File "/usr/bin/qt-deploy", line 507, in run
    self.parseConfig()
  File "/usr/bin/qt-deploy", line 410, in parseConfig
    self.pkgName = self.preparePath(config.get('Deployment', 'pkgName').strip('"'))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ConfigParser.py", line 618, in get
    raise NoOptionError(option, section)
ConfigParser.NoOptionError: No option 'pkgname' in section: 'Deployment'
```